### PR TITLE
Add optional summary field to content collections

### DIFF
--- a/src/content/config.js
+++ b/src/content/config.js
@@ -3,6 +3,7 @@ import { glob, file } from 'astro/loaders';
 
 const metadata = z.object({
   title: z.string(),
+  summary: z.string().optional(),
   link: z.string().url(),
   image: z.string().url().optional(),
   caption: z.string().optional(),
@@ -13,6 +14,7 @@ const expertise = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/expertise' }),
   schema: z.object({
     title: z.string(),
+    summary: z.string().optional(),
     sort: z.number()
   })
 });

--- a/src/content/expertise/design.md
+++ b/src/content/expertise/design.md
@@ -1,5 +1,6 @@
 ---
 title: Design
+summary: Creates scalable design systems that balance consistency with creativity, focusing on accessibility, usability, and cross-disciplinary alignment.
 sort: 1
 ---
 

--- a/src/content/expertise/education.md
+++ b/src/content/expertise/education.md
@@ -1,5 +1,6 @@
 ---
 title: Education
+summary: Develops UX and front-end engineering curricula that bridge industry and academia through hands-on, real-world design systems education.
 sort: 3
 ---
 

--- a/src/content/expertise/engineering.md
+++ b/src/content/expertise/engineering.md
@@ -1,5 +1,6 @@
 ---
 title: Engineering
+summary: Specializes in building scalable UI architectures, component libraries, and design system integrations that bridge design and front-end development.
 sort: 2
 ---
 

--- a/src/content/media/coak-standup.md
+++ b/src/content/media/coak-standup.md
@@ -1,5 +1,6 @@
 ---
 title: The Stand Up
+summary: A podcast conversation on building trustworthy products through design systems, prioritizing user needs and functionality over aesthetics.
 link: https://www.youtube.com/watch?v=V6kcv9BBmDg
 image: https://i3.ytimg.com/vi/V6kcv9BBmDg/maxresdefault.jpg
 caption: A Pretty UI Does Nothing

--- a/src/content/media/code-and-pixels.md
+++ b/src/content/media/code-and-pixels.md
@@ -1,5 +1,6 @@
 ---
 title: Code & Pixels, Ep. 15
+summary: Episode 15 of the Code & Pixels podcast covering design systems and front-end development topics.
 link: https://youtu.be/3BOrvnyQAK0
 image: https://i3.ytimg.com/vi/3BOrvnyQAK0/maxresdefault.jpg
 caption: Code & Pixels

--- a/src/content/media/craft-across-design-tokens.md
+++ b/src/content/media/craft-across-design-tokens.md
@@ -1,5 +1,6 @@
 ---
 title: 'Craft Across: Design Tokens'
+summary: A cross-discipline exploration of craft practices and perspectives across design token workflows and tooling.
 link: https://www.youtube.com/watch?v=Fmrxdr8fZ8w
 image: https://i3.ytimg.com/vi/Fmrxdr8fZ8w/maxresdefault.jpg
 caption: "Craft Across: Design Tokens"

--- a/src/content/media/creativity-within-constraints.md
+++ b/src/content/media/creativity-within-constraints.md
@@ -1,5 +1,6 @@
 ---
 title: Converge 2025, Creativity within Constraints
+summary: Converge 2025 talk arguing that constraints—including design systems—unlock richer, more focused creativity rather than limiting it.
 link: https://webinars.zeroheight.com/videos/2e30a1a5-7a29-4c2a-8c0b-7a14736874b9
 image: https://converge.zeroheight.com/images/thumbnail-donnie-damato.jpg
 caption: Creativity within Constraints

--- a/src/content/media/design-annotation-live.md
+++ b/src/content/media/design-annotation-live.md
@@ -1,5 +1,6 @@
 ---
 title: Design Annotation Live
+summary: A live session on design annotation practices for communicating design intent clearly to engineering teams.
 link: https://www.youtube.com/watch?v=DUzL7648--g
 image: https://i3.ytimg.com/vi/DUzL7648--g/maxresdefault.jpg
 caption: Design Annontation Live

--- a/src/content/media/design-leader-insights.md
+++ b/src/content/media/design-leader-insights.md
@@ -1,5 +1,6 @@
 ---
 title: Design Leader Insights
+summary: A panel discussion on Config updates and design system changes featuring insights from design leaders.
 link: https://www.youtube.com/watch?v=dWaZub6Ytjg
 image: https://i3.ytimg.com/vi/dWaZub6Ytjg/maxresdefault.jpg
 caption: Config and Design System Updates

--- a/src/content/media/design-systems-field-guide.md
+++ b/src/content/media/design-systems-field-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Design Systems Field Guide
+summary: A field guide overview covering practical approaches and foundational concepts for building and maintaining design systems.
 link: https://www.youtube.com/watch?v=8WwV17-BYvQ
 image: https://i3.ytimg.com/vi/8WwV17-BYvQ/maxresdefault.jpg
 caption: Design Systems Field Guide

--- a/src/content/media/dssc-11.md
+++ b/src/content/media/dssc-11.md
@@ -1,5 +1,6 @@
 ---
 title: 'DSSC #11, New Tools'
+summary: Design Systems Social Club episode exploring new tools and emerging technology in the design systems space.
 link: https://www.youtube.com/watch?v=I9Uc6-0Fn9Y
 image: https://i3.ytimg.com/vi/I9Uc6-0Fn9Y/maxresdefault.jpg
 caption: Design Systems Social Club

--- a/src/content/media/dssc-13.md
+++ b/src/content/media/dssc-13.md
@@ -1,5 +1,6 @@
 ---
 title: 'DSSC #13, Managers'
+summary: Design Systems Social Club episode on management, leadership, and organizational challenges in design systems teams.
 link: https://www.youtube.com/watch?v=wN5_JKnZtxM
 image: https://i3.ytimg.com/vi/wN5_JKnZtxM/maxresdefault.jpg
 caption: Design Systems Social Club

--- a/src/content/media/dssc-7.md
+++ b/src/content/media/dssc-7.md
@@ -1,5 +1,6 @@
 ---
 title: 'DSSC #7, Governance'
+summary: Design Systems Social Club episode on governance structures and decision-making frameworks in design systems.
 link: https://www.youtube.com/watch?v=BrCtfoLeteo
 image: https://i.ytimg.com/vi/BrCtfoLeteo/maxresdefault.jpg
 caption: Design Systems Social Club

--- a/src/content/media/dssc-8.md
+++ b/src/content/media/dssc-8.md
@@ -1,5 +1,6 @@
 ---
 title: 'DSSC #8, Exotic Platforms'
+summary: Design Systems Social Club episode discussing design systems challenges on exotic and non-standard platforms.
 link: https://www.youtube.com/watch?v=hRi3VA6sEDA
 image: https://i.ytimg.com/vi/hRi3VA6sEDA/maxresdefault.jpg
 caption: Design Systems Social Club

--- a/src/content/media/dsw-day-2023.md
+++ b/src/content/media/dsw-day-2023.md
@@ -1,5 +1,6 @@
 ---
 title: DSW Day 2023
+summary: DSW Day 2023 talk on token operations and managing design tokens at scale in an organization.
 link: https://youtu.be/DBYcH5Al8u8
 image: https://i3.ytimg.com/vi/DBYcH5Al8u8/maxresdefault.jpg
 caption: Token Operations

--- a/src/content/media/inspect-and-reflect-nord.md
+++ b/src/content/media/inspect-and-reflect-nord.md
@@ -1,5 +1,6 @@
 ---
 title: Inspect & Reflect, Nord Health
+summary: A design systems review session with Nord Health examining their component library and design decisions.
 link: https://www.youtube.com/watch?v=9_S4PrYFPmk
 image: https://i3.ytimg.com/vi/9_S4PrYFPmk/maxresdefault.jpg
 caption: Inspect & Reflect, Nord Health

--- a/src/content/media/inspect-and-reflect-spectrum.md
+++ b/src/content/media/inspect-and-reflect-spectrum.md
@@ -1,5 +1,6 @@
 ---
 title: Inspect & Reflect, Adobe Spectrum
+summary: A design systems review session with the Adobe Spectrum team exploring design decisions and component patterns.
 link: https://www.youtube.com/watch?v=q6ARBhKVqzY
 image: https://i3.ytimg.com/vi/q6ARBhKVqzY/maxresdefault.jpg
 caption: Inspect & Reflect, Adobe Spectrum

--- a/src/content/media/mise-en-mode.md
+++ b/src/content/media/mise-en-mode.md
@@ -1,5 +1,6 @@
 ---
 title: "Clarity 2023, Mise en Mode"
+summary: Clarity 2023 presentation introducing Mise en Mode, a technique using nested modes and scoped semantic tokens to enable expressive design fragments within a consistent system.
 link: https://conffab.com/presentation/mise-en-mode/?gl=6qwtmtB93YWT
 image: https://i.vimeocdn.com/video/1769026057-f0445bc728d67f71851c343bb377bea8f0dadb9d7bd0cad406a01bf671db6be5-d?mw=1500&mh=844&q=70
 caption: Mise en Mode

--- a/src/content/media/state-of-design-tokens-2024.md
+++ b/src/content/media/state-of-design-tokens-2024.md
@@ -1,5 +1,6 @@
 ---
 title: State of Design Tokens 2024
+summary: A 2024 overview of the current state of design tokens, covering community trends, tooling, and evolving best practices.
 link: https://www.youtube.com/watch?v=HNEo0dop4oY
 image: https://i3.ytimg.com/vi/HNEo0dop4oY/maxresdefault.jpg
 caption: State of Design Tokens

--- a/src/content/media/strictly-from-nowhere.md
+++ b/src/content/media/strictly-from-nowhere.md
@@ -1,5 +1,6 @@
 ---
 title: Strictly from Nowhere Podcast
+summary: A podcast appearance on Strictly from Nowhere covering design systems topics and practice.
 link: https://www.youtube.com/watch?v=xLWBnZPwa_0
 image: https://i3.ytimg.com/vi/xLWBnZPwa_0/maxresdefault.jpg
 caption: Strictly from Nowhere

--- a/src/content/media/talking-tokens.md
+++ b/src/content/media/talking-tokens.md
@@ -1,5 +1,6 @@
 ---
 title: Talking Tokens
+summary: A discussion episode focused on design token strategy, tooling, and community practices in the design systems space.
 link: https://www.youtube.com/watch?v=TqyPBEjtycI
 image: https://i3.ytimg.com/vi/TqyPBEjtycI/mqdefault.jpg
 caption: Talking Tokens

--- a/src/content/media/the-future-of-design-systems.md
+++ b/src/content/media/the-future-of-design-systems.md
@@ -1,5 +1,6 @@
 ---
 title: "Clarity 2023, Panel: The Future of Design Systems"
+summary: A Clarity 2023 panel discussion exploring where design systems are headed with leaders across the field.
 link: https://conffab.com/presentation/panel-the-future-of-design-systems/?gl=gc0XQWn7va9d
 image: https://i.vimeocdn.com/video/1766911561-3ed9abadae877e7ae2d916ae1afee3e4891bb348e48e9f371d4350f210ed2d4f-d?mw=1500&mh=844&q=70
 caption: "Panel: The Future of Design Systems"

--- a/src/content/media/theming-in-complex-ecosystems.md
+++ b/src/content/media/theming-in-complex-ecosystems.md
@@ -1,5 +1,6 @@
 ---
 title: Theming in Complex Ecosystems
+summary: A presentation on strategies for managing theming across large, multi-brand design system ecosystems.
 link: https://www.youtube.com/watch?v=DPvxOcWlLn0
 image: https://i3.ytimg.com/vi/DPvxOcWlLn0/mqdefault.jpg
 caption: Theming in Complex Ecosystems

--- a/src/content/media/ux-untamed.md
+++ b/src/content/media/ux-untamed.md
@@ -1,5 +1,6 @@
 ---
 title: UX Untamed Podcast
+summary: A UX Untamed podcast episode exploring the role, responsibilities, and mindset of a UX architect.
 link: https://www.youtube.com/watch?v=tevn_OlmiHw
 image: https://i.ytimg.com/vi/tevn_OlmiHw/maxresdefault.jpg
 caption: What does a UX ARCHITECT do?

--- a/src/content/projects/compass.md
+++ b/src/content/projects/compass.md
@@ -1,5 +1,6 @@
 ---
 title: Compass
+summary: Built and grew Compass's design system from a prototype component library into a cross-organizational resource supporting design consistency and engineering teams.
 link: https://compass.com
 date: 2017-04-15
 ---

--- a/src/content/projects/damatods.md
+++ b/src/content/projects/damatods.md
@@ -1,5 +1,6 @@
 ---
 title: DAMATO Design System
+summary: A personal design system exploring novel token naming conventions, color scales, and component architecture without business constraints.
 link: https://system.damato.design
 image: https://system.damato.design/og-image.png
 caption: DAMATO Design System

--- a/src/content/projects/deltazeus.md
+++ b/src/content/projects/deltazeus.md
@@ -1,5 +1,6 @@
 ---
 title: deltazeus
+summary: A passive weather notification service that sends RSS feed updates only when the weather changes significantly from the previous day.
 link: https://deltazeus.com
 date: 2015-03-22
 ---

--- a/src/content/projects/designtokens.md
+++ b/src/content/projects/designtokens.md
@@ -1,5 +1,6 @@
 ---
 title: designtokens.fyi
+summary: A community reference project defining and standardizing nearly three dozen design token terms to improve shared language across the design systems practice.
 link: https://designtokens.fyi
 image: https://designtokens.fyi/og-image.png
 caption: designtokens.fyi

--- a/src/content/projects/domtricks.md
+++ b/src/content/projects/domtricks.md
@@ -1,5 +1,6 @@
 ---
 title: DOM-Tricks
+summary: A documentation-as-code project where each content page is generated directly from tested, JSDoc-annotated JavaScript source files.
 link: https://dom-tricks.com
 date: 2020-04-03
 ---

--- a/src/content/projects/dshouse.md
+++ b/src/content/projects/dshouse.md
@@ -1,5 +1,6 @@
 ---
 title: DS House
+summary: A consultancy brand and platform hosting multiple projects, content, and communities centered on design systems practice.
 link: https://ds.house
 image: https://ds.house/og-image.png
 caption: ds.house

--- a/src/content/projects/events.md
+++ b/src/content/projects/events.md
@@ -1,5 +1,6 @@
 ---
 title: DS Events
+summary: A community-driven design systems event calendar offering iCal and RSS feeds with self-service event submission via GitHub pull requests.
 link: https://ds.events
 image: https://ds.events/og-image.png
 caption: ds.events

--- a/src/content/projects/galvanize.md
+++ b/src/content/projects/galvanize.md
@@ -1,5 +1,6 @@
 ---
 title: Galvanize
+summary: Volunteered to lead intro-to-coding meetups at Galvanize NYC, teaching HTML, CSS, and JavaScript to diverse audiences through real-world analogies.
 link: https://galvanize.com
 date: 2017-09-01
 ---

--- a/src/content/projects/godaddy.md
+++ b/src/content/projects/godaddy.md
@@ -1,5 +1,6 @@
 ---
 title: GoDaddy
+summary: Led GoDaddy's UXCore component library, introducing CSS Custom Properties-based theming and evolving the library toward composable, semantic token architecture.
 link: https://godaddy.com
 date: 2019-07-28
 ---

--- a/src/content/projects/gridless.md
+++ b/src/content/projects/gridless.md
@@ -1,5 +1,6 @@
 ---
 title: Gridless Design
+summary: An educational resource challenging traditional grid-based design in favor of leveraging native web layout algorithms for responsive design.
 link: https://gridless.design
 image: https://gridless.design/og-image.jpg
 caption: gridless.design

--- a/src/content/projects/itemize.md
+++ b/src/content/projects/itemize.md
@@ -1,5 +1,6 @@
 ---
 title: Itemize
+summary: Led front-end development and UX improvements at an early-stage startup, rebuilding their web app and redesigning the data-entry experience.
 link: https://itemize.com
 date: 2015-05-15
 ---

--- a/src/content/projects/miseenmode.md
+++ b/src/content/projects/miseenmode.md
@@ -1,5 +1,6 @@
 ---
 title: Mise en Mode
+summary: A design systems technique using nested modes and scoped semantic tokens to enable expressive design fragments within a consistent system.
 link: https://mode.place
 image: https://mode.place/og-image.png
 caption: mode.place

--- a/src/content/projects/nextup.md
+++ b/src/content/projects/nextup.md
@@ -1,5 +1,6 @@
 ---
 title: NextUp
+summary: A tournament management platform that automated bracket progression and competitor notifications via SMS to reduce manual coordination at gaming events.
 link: https://nextup.me
 date: 2014-07-27
 ---

--- a/src/content/projects/nyit.md
+++ b/src/content/projects/nyit.md
@@ -1,5 +1,6 @@
 ---
 title: NYIT
+summary: Taught live event production courses at NYIT, guiding students through preproduction, streaming, and building a brand and audience for live shows.
 link: https://nyit.edu
 date: 2014-05-23
 ---

--- a/src/content/projects/parsons.md
+++ b/src/content/projects/parsons.md
@@ -1,5 +1,6 @@
 ---
 title: Parsons School of Design
+summary: Facilitated user research and interaction design courses at Parsons, guiding students through research studies, wireframes, and prototype development.
 link: https://newschool.edu/parsons
 date: 2020-01-30
 ---

--- a/src/content/projects/roxorgames.md
+++ b/src/content/projects/roxorgames.md
@@ -1,5 +1,6 @@
 ---
 title: Roxor Games
+summary: Served as a gameplay artist for In The Groove 3, creating step charts for nearly 70% of the game drawing on deep expertise in rhythm game design.
 link: https://roxorgames.com
 date: 2006-08-16
 ---

--- a/src/content/projects/willarrive.md
+++ b/src/content/projects/willarrive.md
@@ -1,5 +1,6 @@
 ---
 title: willarrive.in
+summary: A minimal progressive web app that uses geolocation to instantly show when the next train arrives at the nearest station on a chosen line.
 link: https://willarrive.in
 date: 2016-03-22
 ---

--- a/src/pages/llms.txt.js
+++ b/src/pages/llms.txt.js
@@ -21,7 +21,7 @@ function collectionToSection(title, entries) {
       const label = entry.data?.title;
       const mdPath = new URL(`/${entry.collection}/${entry.id}.md`, origin);
       const date = entry.data?.date;
-      const description = entry.body ? mdastToPlainText(fromMarkdown(entry.body)) : '';
+      const description = entry.data?.summary ?? '';
 
       const dateStr = date
         ? new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date)


### PR DESCRIPTION
## Summary
This PR adds an optional `summary` field to the content schema for expertise, media, and projects collections, and updates the llms.txt generation to use these summaries instead of parsing markdown body content.

## Key Changes
- **Schema updates**: Added optional `summary: z.string().optional()` field to metadata and expertise collection schemas in `src/content/config.js`
- **llms.txt generation**: Modified `src/pages/llms.txt.js` to use `entry.data?.summary` instead of parsing markdown body with `mdastToPlainText(fromMarkdown(entry.body))`
- **Content population**: Added curated summary text to all 30+ content files across expertise, media, and projects collections

## Implementation Details
The summary field is optional, allowing for gradual adoption across content. The llms.txt page now prefers the explicit summary field with a fallback to empty string, eliminating the need for markdown parsing and providing more control over how content is described in that context.

https://claude.ai/code/session_018fimagm7P8nwnWnaZN7tdg